### PR TITLE
Show fruits on the map

### DIFF
--- a/src/components/FruitMap.tsx
+++ b/src/components/FruitMap.tsx
@@ -3,10 +3,14 @@
 import { useState } from "react";
 import { useGeolocation } from "@uidotdev/usehooks";
 import Map, { Marker } from "react-map-gl";
+import useNearbyFruits from "@/hooks/useNearbyFruits";
 import "mapbox-gl/dist/mapbox-gl.css";
+import { FruitLocation } from "@/types";
+import fruitIcon from "@/utils/fruitIcon";
 
 export default function FruitMap({ token }) {
   const state = useGeolocation();
+  const [fruits] = useNearbyFruits();
   const [isStreet, setIsStreet] = useState(true);
 
   if (state.loading) {
@@ -35,6 +39,24 @@ export default function FruitMap({ token }) {
             : "mapbox://styles/mapbox/satellite-streets-v12"
         }
       >
+        {fruits.map((fruitLocation: FruitLocation) => (
+          <>
+            <Marker
+              key={fruitLocation.id}
+              latitude={fruitLocation.latitude}
+              longitude={fruitLocation.longitude}
+              color="white"
+            />
+            <Marker
+              key={fruitLocation.id}
+              latitude={fruitLocation.latitude}
+              longitude={fruitLocation.longitude}
+              offset={[0, -20]}
+            >
+              <span className="text-xl">{fruitIcon(fruitLocation.fruit)}</span>
+            </Marker>
+          </>
+        ))}
         <Marker longitude={state.longitude} latitude={state.latitude} />
       </Map>
 

--- a/src/hooks/useNearbyFruits.ts
+++ b/src/hooks/useNearbyFruits.ts
@@ -3,13 +3,16 @@ import { useEffect, useState } from "react";
 
 function useNearbyFruits() {
   const [fruits, setFruits] = useState<FruitLocation[]>([]);
+  const [south, setSouth] = useState<number>(-90);
+  const [north, setNorth] = useState<number>(90);
+  const [west, setWest] = useState<number>(-180);
+  const [east, setEast] = useState<number>(180);
 
-  // TODO set map bounds
   // This useEffect with empty [] gets called once when the component is created
   useEffect(() => {
     const fetchData = async () => {
       const response = await fetch(
-        "/api/fruit_locations?east=180&west=-180&north=90&south=-90"
+        `/api/fruit_locations?east=${east}&west=${west}&north=${north}&south=${south}`
       );
       const data = await response.json();
 
@@ -26,9 +29,16 @@ function useNearbyFruits() {
       setFruits(fruitData);
     };
     fetchData();
-  }, []);
+  }, [east, north, south, west]);
 
-  return [fruits];
+  const setBounds = (n: number, e: number, w: number, s: number) => {
+    setNorth(n);
+    setEast(e);
+    setWest(w);
+    setSouth(s);
+  };
+
+  return [fruits, setBounds];
 }
 
 export default useNearbyFruits;

--- a/src/hooks/useNearbyFruits.ts
+++ b/src/hooks/useNearbyFruits.ts
@@ -1,7 +1,12 @@
 import { type FruitLocation } from "@/types";
 import { useEffect, useState } from "react";
 
-function useNearbyFruits() {
+type NearbyFruits = [
+  FruitLocation[],
+  (n: number, e: number, w: number, s: number) => void
+];
+
+function useNearbyFruits(): NearbyFruits {
   const [fruits, setFruits] = useState<FruitLocation[]>([]);
   const [south, setSouth] = useState<number>(-90);
   const [north, setNorth] = useState<number>(90);

--- a/src/hooks/useNearbyFruits.ts
+++ b/src/hooks/useNearbyFruits.ts
@@ -1,0 +1,34 @@
+import { type FruitLocation } from "@/types";
+import { useEffect, useState } from "react";
+
+function useNearbyFruits() {
+  const [fruits, setFruits] = useState<FruitLocation[]>([]);
+
+  // TODO set map bounds
+  // This useEffect with empty [] gets called once when the component is created
+  useEffect(() => {
+    const fetchData = async () => {
+      const response = await fetch(
+        "/api/fruit_locations?east=180&west=-180&north=90&south=-90"
+      );
+      const data = await response.json();
+
+      // Re-map api data to FruitLocation object
+      const fruitData = data.map((item: any) => {
+        const fruitLocation: FruitLocation = {
+          id: item.id,
+          fruit: item.fruit_name,
+          latitude: item.latitude,
+          longitude: item.longitude,
+        };
+        return fruitLocation;
+      });
+      setFruits(fruitData);
+    };
+    fetchData();
+  }, []);
+
+  return [fruits];
+}
+
+export default useNearbyFruits;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,6 @@
+export type FruitLocation = {
+  id: number;
+  fruit: string;
+  latitude: number;
+  longitude: number;
+};

--- a/src/utils/fruitIcon.ts
+++ b/src/utils/fruitIcon.ts
@@ -1,0 +1,46 @@
+export default function fruitIcon(name: string) {
+  switch (name) {
+    case "Banana":
+      return "🍌";
+    case "Strawberry":
+      return "🍓";
+    case "Blueberry":
+      return "🫐";
+    case "Apple":
+      return "🍎";
+    case "Green Apple":
+      return "🍏";
+    case "Grape":
+      return "🍇";
+    case "Watermelon":
+      return "🍉";
+    case "Honeydew":
+      return "🍈";
+    case "Avocado":
+      return "🥑";
+    case "Mandarin":
+      return "🍊";
+    case "Orange":
+      return "🍊";
+    case "Peach":
+      return "🍑";
+    case "Pineapple":
+      return "🍍";
+    case "Cherry":
+      return "🍒";
+    case "Pear":
+      return "🍐";
+    case "Lemon":
+      return "🍋";
+    case "Lime":
+      return "🍋‍🟩";
+    case "Kiwi":
+      return "🥝";
+    case "Mango":
+      return "🥭";
+    case "Tangerine":
+      return "🍊";
+    default:
+      return "🌳";
+  }
+}


### PR DESCRIPTION
Show nearby fruits on the map using API.

- Add useNearbyFruits hook to manage fruit data in API call.
- Updated FruitMap to use hook.
- Update map bounds to use in API call when map is loaded, dragged, or zoomed.
- Show fruit marker using fruit emojis, added utility to lookup icon from fruit name.

<img width="531" alt="Screenshot 2024-04-27 at 3 02 57 PM" src="https://github.com/alexmerino13/fruit-finder/assets/55523823/01333056-a00d-40ed-842f-8f5cafb6c3de">
