### PR TITLE
Add fruit locations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -386,6 +386,126 @@
         "glob": "10.3.10"
       }
     },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.4.tgz",
+      "integrity": "sha512-ubmUkbmW65nIAOmoxT1IROZdmmJMmdYvXIe8211send9ZYJu+SqxSnJM4TrPj9wmL6g9Atvj0S/2cFmMSS99jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.4.tgz",
+      "integrity": "sha512-b0Xo1ELj3u7IkZWAKcJPJEhBop117U78l70nfoQGo4xUSvv0PJSTaV4U9xQBLvZlnjsYkc8RwQN1HoH/oQmLlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.4.tgz",
+      "integrity": "sha512-457G0hcLrdYA/u1O2XkRMsDKId5VKe3uKPvrKVOyuARa6nXrdhJOOYU9hkKKyQTMru1B8qEP78IAhf/1XnVqKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.4.tgz",
+      "integrity": "sha512-l/kMG+z6MB+fKA9KdtyprkTQ1ihlJcBh66cf0HvqGP+rXBbOXX0dpJatjZbHeunvEHoBBS69GYQG5ry78JMy3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.4.tgz",
+      "integrity": "sha512-BapIFZ3ZRnvQ1uWbmqEGJuPT9cgLwvKtxhK/L2t4QYO7l+/DxXuIGjvp1x8rvfa/x1FFSsipERZK70pewbtJtw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.4.tgz",
+      "integrity": "sha512-mqVxTwk4XuBl49qn2A5UmzFImoL1iLm0KQQwtdRJRKl21ylQwwGCxJtIYo2rbfkZHoSKlh/YgztY0qH3wG1xIg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.4.tgz",
+      "integrity": "sha512-xzxF4ErcumXjO2Pvg/wVGrtr9QQJLk3IyQX1ddAC/fi6/5jZCZ9xpuL9Tzc4KPWMFq8GGWFVDMshZOdHGdkvag==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.4.tgz",
+      "integrity": "sha512-WZiz8OdbkpRw6/IU/lredZWKKZopUMhcI2F+XiMAcPja0uZYdMTZQRoQ0WZcvinn9xZAidimE7tN9W5v9Yyfyw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-win32-x64-msvc": {
       "version": "14.1.4",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.4.tgz",

--- a/src/components/AddMap.tsx
+++ b/src/components/AddMap.tsx
@@ -1,0 +1,37 @@
+import { useRef, useState } from "react";
+import Map, { Marker, type MapRef } from "react-map-gl";
+import "mapbox-gl/dist/mapbox-gl.css";
+import fruitIcon from "@/utils/fruitIcon";
+
+export default function AddMap({ fruit, latitude, longitude, token, onClick }) {
+  const mapRef = useRef<MapRef>();
+  const [isStreet, setIsStreet] = useState(false);
+
+  return (
+    <>
+      <Map
+        ref={mapRef}
+        mapboxAccessToken={token}
+        initialViewState={{
+          longitude: longitude,
+          latitude: latitude,
+          zoom: 19,
+        }}
+        style={{ height: "30vh" }}
+        mapStyle={
+          isStreet
+            ? "mapbox://styles/mapbox/streets-v12"
+            : "mapbox://styles/mapbox/satellite-streets-v12"
+        }
+        onClick={(e) => {
+          onClick(e.lngLat.lat, e.lngLat.lng);
+        }}
+      >
+        <Marker latitude={latitude} longitude={longitude} color="white" />
+        <Marker latitude={latitude} longitude={longitude} offset={[0, -20]}>
+          <span className="text-xl">{fruitIcon(fruit)}</span>
+        </Marker>
+      </Map>
+    </>
+  );
+}

--- a/src/components/AddModal.tsx
+++ b/src/components/AddModal.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { ExclamationCircleIcon } from "@heroicons/react/16/solid";
+import fruitIcon from "@/utils/fruitIcon";
+import AddMap from "./AddMap";
+import useFruits from "@/hooks/useFruits";
+import useAddFruit from "@/hooks/useAddFruit";
+import { Fruit } from "@/types";
+
+export default function AddModal({ token, lat, lng, onClose, onAdd }) {
+  const [fruitType, setFruitType] = useState<Fruit>();
+  const [latitude, setLatitude] = useState(lat);
+  const [longitude, setLongitude] = useState(lng);
+  const [fruits, loading] = useFruits();
+  const [addFruit, saving, error] = useAddFruit();
+
+  async function saveFruit() {
+    await addFruit(fruitType, latitude, longitude);
+    onAdd();
+  }
+
+  return (
+    <dialog className="modal modal-open">
+      <div className="modal-box">
+        <form method="dialog">
+          <button
+            className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+            onClick={() => onClose()}
+          >
+            ✕
+          </button>
+        </form>
+        <h3 className="font-bold text-lg mb-4">Add Fruit</h3>
+        {error ? (
+          <div role="alert" className="alert alert-error mb-4">
+            <ExclamationCircleIcon className="h-6 w-6" />
+            <span>Error! Unable to add fruit.</span>
+          </div>
+        ) : (
+          <></>
+        )}
+
+        <AddMap
+          fruit={fruitType?.name}
+          latitude={latitude}
+          longitude={longitude}
+          token={token}
+          onClick={(lt, ln) => {
+            setLatitude(lt);
+            setLongitude(ln);
+          }}
+        />
+
+        <select
+          disabled={loading}
+          className="select select-bordered select-lg w-full mt-3"
+          value={fruitType?.id}
+          onChange={(e) => {
+            const fruit = fruits.find((f) => f.id == parseInt(e.target.value));
+            setFruitType(fruit);
+          }}
+        >
+          <option disabled selected>
+            What type of fruit?
+          </option>
+          {fruits.map((fruit: Fruit) => (
+            <option key={fruit.id} value={fruit.id}>
+              {fruitIcon(fruit.name)} {fruit.name}
+            </option>
+          ))}
+        </select>
+        <div className="modal-action">
+          <button
+            className="btn btn-primary"
+            disabled={!fruitType || saving}
+            onClick={() => {
+              saveFruit();
+            }}
+          >
+            {saving ? "Saving..." : "Add"}
+          </button>
+          <button className="btn btn-outline" onClick={() => onClose()}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/src/components/FruitMap.tsx
+++ b/src/components/FruitMap.tsx
@@ -1,19 +1,24 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { useSession } from "next-auth/react";
 import { useGeolocation } from "@uidotdev/usehooks";
 import Map, { Marker, type MapRef } from "react-map-gl";
+import { PlusCircleIcon } from "@heroicons/react/16/solid";
 import useNearbyFruits from "@/hooks/useNearbyFruits";
 import useSpecificFruit from "@/hooks/useSpecificFruit";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { FruitLocation } from "@/types";
 import fruitIcon from "@/utils/fruitIcon";
-import SlidingPanel from 'react-sliding-side-panel';
-import Image from 'next/image'
+import SlidingPanel from "react-sliding-side-panel";
+import Image from "next/image";
+import AddModal from "./AddModal";
 
 export default function FruitMap({ token }) {
   const mapRef = useRef<MapRef>();
   const state = useGeolocation();
+  const [modalOpen, setModalOpen] = useState(false);
+  const { status } = useSession();
   const [fruits, setBounds] = useNearbyFruits();
   const [isStreet, setIsStreet] = useState(true);
   const [selectedFruit, setSelectedFruit] = useSpecificFruit();
@@ -47,58 +52,72 @@ export default function FruitMap({ token }) {
   return (
     <>
       <div>
-      <Map
-        ref={mapRef}
-        mapboxAccessToken={token}
-        initialViewState={{
-          longitude: state.longitude,
-          latitude: state.latitude,
-          zoom: 16,
-        }}
-        // TODO - make height fill view port:
-        style={{ height: "88vh" }}
-        mapStyle={
-          isStreet
-            ? "mapbox://styles/mapbox/streets-v12"
-            : "mapbox://styles/mapbox/satellite-streets-v12"
-        }
-        onDragEnd={updateBounds}
-        onLoad={updateBounds}
-        onZoomEnd={updateBounds}
-        onDragStart={() => {
+        <Map
+          ref={mapRef}
+          mapboxAccessToken={token}
+          initialViewState={{
+            longitude: state.longitude,
+            latitude: state.latitude,
+            zoom: 16,
+          }}
+          // TODO - make height fill view port:
+          style={{ height: "88vh" }}
+          mapStyle={
+            isStreet
+              ? "mapbox://styles/mapbox/streets-v12"
+              : "mapbox://styles/mapbox/satellite-streets-v12"
+          }
+          onDragEnd={updateBounds}
+          onLoad={updateBounds}
+          onZoomEnd={updateBounds}
+          onDragStart={() => {
             setOpenPanel(false);
-        }}
-      >
-        {fruits.map((fruitLocation: FruitLocation) => (
-          <>
-            <Marker
-              key={`${fruitLocation.id}-bg`}
-              latitude={fruitLocation.latitude}
-              longitude={fruitLocation.longitude}
-              color="white"
-            />
-            <Marker
-              key={fruitLocation.id}
-              latitude={fruitLocation.latitude}
-              longitude={fruitLocation.longitude}
-              offset={[0, -20]}
-              // Unsure about this behavior. Could see user wanting to keep panel on screen as they navigate around
-              onClick={() => {
-                setOpenPanel(false);
-                panelLoad(fruitLocation.id);
-              }}
-            >
-              <span className="text-xl">{fruitIcon(fruitLocation.fruit)}</span>
-            </Marker>
-          </>
-        ))}
-        <Marker longitude={state.longitude} latitude={state.latitude} />
-      </Map>
+          }}
+        >
+          {fruits.map((fruitLocation: FruitLocation) => (
+            <>
+              <Marker
+                key={`${fruitLocation.id}-bg`}
+                latitude={fruitLocation.latitude}
+                longitude={fruitLocation.longitude}
+                color="white"
+              />
+              <Marker
+                key={fruitLocation.id}
+                latitude={fruitLocation.latitude}
+                longitude={fruitLocation.longitude}
+                offset={[0, -20]}
+                // Unsure about this behavior. Could see user wanting to keep panel on screen as they navigate around
+                onClick={() => {
+                  setOpenPanel(false);
+                  panelLoad(fruitLocation.id);
+                }}
+              >
+                <span className="text-xl">
+                  {fruitIcon(fruitLocation.fruit)}
+                </span>
+              </Marker>
+            </>
+          ))}
+          <Marker longitude={state.longitude} latitude={state.latitude} />
+        </Map>
       </div>
 
       <div className="navbar bg-white fixed bottom-0 z-10">
         <div className="navbar-start"></div>
-        <div className="navbar-center"></div>
+        <div className="navbar-center">
+          {status === "authenticated" ? (
+            <button
+              className="btn btn-primary"
+              onClick={() => setModalOpen(true)}
+            >
+              <PlusCircleIcon className="h-6 w-6" /> Add Fruit
+            </button>
+          ) : (
+            // TODO show log in button if user not logged in
+            <></>
+          )}
+        </div>
         <div className="navbar-end">
           <button
             className={`btn btn-sm mr-2 ${isStreet ? "btn-active" : ""}`}
@@ -115,7 +134,7 @@ export default function FruitMap({ token }) {
         </div>
       </div>
       <SlidingPanel
-        type={'left'}
+        type={"left"}
         isOpen={openPanel}
         backdropClicked={() => setOpenPanel(false)}
         size={22}
@@ -124,39 +143,85 @@ export default function FruitMap({ token }) {
         noBackdrop={true}
       >
         {/* TODO:
-          * Remove panel close button, or stick it to bottom of panel (with relative positioning?)
-          * Build out review list interface, with each review probably needing username, rating, and comment (optional)
-          * Edit button - probably far easier if this takes user to a route w/ a form. Only visible if user created this location
-          */}
+         * Remove panel close button, or stick it to bottom of panel (with relative positioning?)
+         * Build out review list interface, with each review probably needing username, rating, and comment (optional)
+         * Edit button - probably far easier if this takes user to a route w/ a form. Only visible if user created this location
+         */}
         <div className="panel-container grid grid-cols-1 gap-4 content-evenly text-center">
-          <Image src={selectedFruit ? selectedFruit.img_link : ''} alt="fruit_tree_image" height={250} width={450}></Image>
+          <Image
+            src={selectedFruit ? selectedFruit.img_link : ""}
+            alt="fruit_tree_image"
+            height={250}
+            width={450}
+          ></Image>
           <div className="px-4 text-start">
-            <div><span className="font-semibold text-lg">{selectedFruit ? selectedFruit.name : ''}</span></div>
+            <div>
+              <span className="font-semibold text-lg">
+                {selectedFruit ? selectedFruit.name : ""}
+              </span>
+            </div>
             {/*Reviews average, placeholder until fleshing out that system more*/}
-            <div><span>★★★★</span><span>☆</span></div>
+            <div>
+              <span>★★★★</span>
+              <span>☆</span>
+            </div>
           </div>
           <div className="grid grid-cols-2 px-4">
-            <div><button className="btn btn-sm col-span-1" onClick={() => setPanelSection(0)}>Overview</button></div>
-            <div><button className="btn btn-sm col-span-1" onClick={() => setPanelSection(1)}>Reviews</button></div>
+            <div>
+              <button
+                className="btn btn-sm col-span-1"
+                onClick={() => setPanelSection(0)}
+              >
+                Overview
+              </button>
+            </div>
+            <div>
+              <button
+                className="btn btn-sm col-span-1"
+                onClick={() => setPanelSection(1)}
+              >
+                Reviews
+              </button>
+            </div>
           </div>
           <div className="text-start px-4">
-          {
-            panelSection === 0 ? 
+            {panelSection === 0 ? (
               <div>
-                <p>{selectedFruit ? selectedFruit.description : ''}</p>
-              </div> 
-            : 
+                <p>{selectedFruit ? selectedFruit.description : ""}</p>
+              </div>
+            ) : (
               <div>
                 <div>Review list here..?</div>
               </div>
-          }
+            )}
           </div>
-          <button type="button" className="close-button btn btn-sm mx-4 mt-18" onClick={() => setOpenPanel(false)}>
+          <button
+            type="button"
+            className="close-button btn btn-sm mx-4 mt-18"
+            onClick={() => setOpenPanel(false)}
+          >
             Close Panel
           </button>
         </div>
       </SlidingPanel>
       <div></div>
+
+      {/* Conditionally render modal so state is reset each time opened */}
+      {modalOpen ? (
+        <AddModal
+          token={token}
+          lat={state.latitude}
+          lng={state.longitude}
+          onAdd={() => {
+            setModalOpen(false);
+            updateBounds();
+            // TODO notify user of successful add
+          }}
+          onClose={() => setModalOpen(false)}
+        />
+      ) : (
+        <></>
+      )}
     </>
   );
 }

--- a/src/components/UserBadge.tsx
+++ b/src/components/UserBadge.tsx
@@ -4,7 +4,11 @@
 import { useSession } from "next-auth/react";
 
 export default function UserBadge() {
-  const { data } = useSession();
+  const { data, status } = useSession();
+
+  if (status !== "authenticated") {
+    return <></>;
+  }
 
   return (
     <div className="p-3">

--- a/src/hooks/useAddFruit.ts
+++ b/src/hooks/useAddFruit.ts
@@ -1,0 +1,46 @@
+import { Fruit } from "@/types";
+import { useState } from "react";
+
+// This is the hook return type
+type AddFruitData = [
+  (fruit: Fruit, latitude: number, longitude: number) => void,
+  boolean,
+  boolean
+];
+
+export default function useAddFruit(): AddFruitData {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(false);
+
+  async function addFruit(
+    fruit: Fruit,
+    latitude: number,
+    longitude: number
+  ): Promise<void> {
+    setSaving(true);
+
+    const data = {
+      name: fruit.name,
+      fruit_id: fruit.id,
+      latitude,
+      longitude,
+    };
+    try {
+      const response = await fetch("/api/fruit_locations", {
+        method: "POST", // Specify the HTTP method as POST
+        headers: {
+          "Content-Type": "application/json", // Set the Content-Type header to indicate JSON data
+        },
+        body: JSON.stringify(data), // Stringify the JavaScript object into JSON format
+      });
+
+      if (!response.ok) throw new Error(response.statusText);
+    } catch (e) {
+      console.error(e);
+      setError(true);
+    }
+    setSaving(false);
+  }
+
+  return [addFruit, saving, error];
+}

--- a/src/hooks/useFruits.ts
+++ b/src/hooks/useFruits.ts
@@ -1,0 +1,37 @@
+import { type Fruit } from "@/types";
+import { useEffect, useState } from "react";
+
+// This is the hook return type
+type FruitsData = [Fruit[], boolean];
+
+function useFruits(): FruitsData {
+  const [fruits, setFruits] = useState<Fruit[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // This useEffect with empty [] gets called once when the component is created
+  useEffect(() => {
+    const fetchData = async () => {
+      const response = await fetch("/api/fruits");
+      const data = await response.json();
+
+      // Re-map api data to Fruit object
+      const fruitData = data
+        .map((item: any) => {
+          const fruit: Fruit = {
+            id: item.fruit_id,
+            name: item.fruit_name,
+          };
+          return fruit;
+        })
+        .sort((a: Fruit, b: Fruit) => a.name.localeCompare(b.name));
+
+      setFruits(fruitData);
+      setLoading(false);
+    };
+    fetchData();
+  }, []);
+
+  return [fruits, loading];
+}
+
+export default useFruits;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,1 +1,3 @@
 export { default } from "next-auth/middleware";
+
+export const config = { matcher: ["/fruits", "/api/:path*"] };

--- a/src/sql/1.fruits.sql
+++ b/src/sql/1.fruits.sql
@@ -1,10 +1,9 @@
 CREATE TABLE IF NOT EXISTS Fruits (
 	id SERIAL PRIMARY KEY,
 	name VARCHAR(255) NOT NULL,
-	color VARCHAR(255) NOT NULL
+	color VARCHAR(255) 
 );
 
 INSERT INTO Fruits (name, color)
 VALUES ('Blackberry', '35, 3, 48'),
-('Golden Plum', '199, 190, 91'),
-('Cherry', '196, 106, 147');
+('Plum', '199, 190, 91'), ('Cherry', '196, 106, 147'), ('Apple', NULL), ('Avocado', NULL), ('Banana', NULL), ('Blueberry', NULL), ('Grape', NULL), ('Green Apple', NULL), ('Honeydew', NULL), ('Kiwi', NULL), ('Lemon', NULL), ('Lime', NULL), ('Mandarin', NULL), ('Mango', NULL), ('Orange', NULL), ('Peach', NULL), ('Pear', NULL), ('Pineapple', NULL), ('Strawberry', NULL), ('Tangerine', NULL), ('Watermelon', NULL);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,4 +13,9 @@ export type FruitLocationDetail = {
   latitude: number;
   longitude: number;
   img_link: string;
-}
+};
+
+export type Fruit = {
+  id: number;
+  name: string;
+};


### PR DESCRIPTION
Let user add new fruit location.

- Add fruit modal to fruit map
- Add new useAddFruit hook, to call api/fruit_locations to save fruit location
- Dynamically load list of fruits from api
- Updated types
- Updated sql to pre-populate fruits list

Auth:
- Updated Auth to make home page public and protect FruitMap and api(s)
- Updated UserBadge to work on public pages
- Hide Add button when user is not logged in
- Updated package-lock

Note: We can add more fields (i.e. notes/description, image) to add modal in next PRs.

<img width="776" alt="Screenshot 2024-05-06 at 12 21 10 PM" src="https://github.com/alexmerino13/fruit-finder/assets/55523823/10ad193e-d022-4de8-a8a5-095899fed2c7">


