### PR TITLE
Code Review suggestion: simplify useNearbyFruits usage

### DIFF
--- a/src/app/api/fruit_locations/route.ts
+++ b/src/app/api/fruit_locations/route.ts
@@ -140,7 +140,7 @@ export async function GET(request: Request) {
         }
     } else if(east && west && north && south) {
         // Fetch all fruit tree locations within a specified bounding box
-        if(fruitId != "-1") {
+        if(fruitId) {
             try {
                 fruitTreeLocations = await sql`
                     SELECT 

--- a/src/components/FruitMap.tsx
+++ b/src/components/FruitMap.tsx
@@ -14,7 +14,7 @@ import useNearbyFruits from "@/hooks/useNearbyFruits";
 import useSpecificFruit from "@/hooks/useSpecificFruit";
 import useLocationReviews from "@/hooks/useLocationReviews";
 import "mapbox-gl/dist/mapbox-gl.css";
-import { FruitLocation } from "@/types";
+import { Fruit, FruitLocation } from "@/types";
 import fruitIcon from "@/utils/fruitIcon";
 import AddModal from "./AddModal";
 import SideBar from "./SideBar";
@@ -138,7 +138,11 @@ export default function FruitMap({ token }) {
           }}
         >
           <SearchBar onSearchSubmit={retrieveSearch} />
-          <FruitFilter handleFilter={(fruit) => setFruitFilter(fruit)} />
+          <FruitFilter
+            handleFilter={(fruit: Fruit) => {
+              setFruitFilter(fruit.id === -1 ? undefined : fruit);
+            }}
+          />
           {fruits.map((fruitLocation: FruitLocation) => (
             <>
               <Marker

--- a/src/hooks/useNearbyFruits.ts
+++ b/src/hooks/useNearbyFruits.ts
@@ -1,9 +1,11 @@
-import { type FruitLocation } from "@/types";
+import { Fruit, type FruitLocation } from "@/types";
 import { useEffect, useState } from "react";
 
 type NearbyFruits = [
   FruitLocation[],
-  (n: number, e: number, w: number, s: number, fruitFilter: number) => void
+  (n: number, e: number, w: number, s: number) => void,
+  (filter: Fruit) => void,
+  Fruit
 ];
 
 function useNearbyFruits(): NearbyFruits {
@@ -12,13 +14,13 @@ function useNearbyFruits(): NearbyFruits {
   const [north, setNorth] = useState<number>(90);
   const [west, setWest] = useState<number>(-180);
   const [east, setEast] = useState<number>(180);
-  const [fruitFilter, setFruitFilter] = useState<number>(-1);
+  const [filter, setFilter] = useState<Fruit>();
 
   // This useEffect with empty [] gets called once when the component is created
   useEffect(() => {
     const fetchData = async () => {
       const response = await fetch(
-        `/api/fruit_locations?east=${east}&west=${west}&north=${north}&south=${south}&fruit_id=${fruitFilter}`
+        `/api/fruit_locations?east=${east}&west=${west}&north=${north}&south=${south}`
       );
       const data = await response.json();
 
@@ -35,17 +37,20 @@ function useNearbyFruits(): NearbyFruits {
       setFruits(fruitData);
     };
     fetchData();
-  }, [east, north, south, west, fruitFilter]);
+  }, [east, north, south, west]);
 
-  const setBounds = (n: number, e: number, w: number, s: number, fruitFilter: number) => {
+  const setBounds = (n: number, e: number, w: number, s: number) => {
     setNorth(n);
     setEast(e);
     setWest(w);
     setSouth(s);
-    setFruitFilter(fruitFilter);
   };
 
-  return [fruits, setBounds];
+  // If there is a filter, return filtered list of fruit locations, else all
+  const filteredFruit = filter
+    ? fruits.filter((item: FruitLocation) => item.fruit === filter.name)
+    : fruits;
+  return [filteredFruit, setBounds, setFilter, filter];
 }
 
 export default useNearbyFruits;


### PR DESCRIPTION
This PR is based off your add-fruitmap-search PR branch.  It modifies the PR by doing the following:

- Manage fruit filter state in hook
- Simplify FruitMap changes by just calling setFruitFilter
- Leverage client side filtering (since we already have all the fruit location data anyways)
- Revert the now unneeded route.ts change, and also the passing fruit.id in setBounds
- Sorry for some prettier reformatting of touched code

**If you approve, you can merge this back to your branch and current PR will be updated.**