### PR TITLE
Bugfix - s3 file upload

### DIFF
--- a/src/hooks/useAddFruit.ts
+++ b/src/hooks/useAddFruit.ts
@@ -54,8 +54,7 @@ export default function useAddFruit(): AddFruitData {
           const uploadResponse = await fetch(url, {
             method: "POST",
             headers: { 
-              "Cache-Control": 'no-cache',
-              "Origin": "https://fruit-finder.vercel.app",
+              "Cache-Control": 'no-cache'
             },
             body: formData,
           });

--- a/src/hooks/useAddFruit.ts
+++ b/src/hooks/useAddFruit.ts
@@ -55,7 +55,7 @@ export default function useAddFruit(): AddFruitData {
             method: "POST",
             headers: { 
               "Cache-Control": 'no-cache',
-              "Origin": null,
+              "Origin": "https://fruit-finder.vercel.app",
             },
             body: formData,
           });
@@ -69,6 +69,8 @@ export default function useAddFruit(): AddFruitData {
           console.error("Failed to get pre-signed URL.");
         }
       }
+    } catch (e) {
+      console.error(e);
     } finally {
 
       // TODO const s3_img_link = await uploadImage(file);

--- a/src/hooks/useEditFruit.ts
+++ b/src/hooks/useEditFruit.ts
@@ -55,7 +55,7 @@ export default function useEditFruit(): EditFruitData {
             method: "POST",
             headers: { 
               "Cache-Control": 'no-cache',
-              "Origin": null,
+              "Origin": "https://fruit-finder.vercel.app",
             },
             body: formData,
           });
@@ -69,6 +69,8 @@ export default function useEditFruit(): EditFruitData {
           console.error("Failed to get pre-signed URL.");
         }
       }
+    } catch (e) {
+      console.error(e);
     } finally {
       const data = {
         name: fruit.name,

--- a/src/hooks/useEditFruit.ts
+++ b/src/hooks/useEditFruit.ts
@@ -54,8 +54,7 @@ export default function useEditFruit(): EditFruitData {
           const uploadResponse = await fetch(url, {
             method: "POST",
             headers: { 
-              "Cache-Control": 'no-cache',
-              "Origin": "https://fruit-finder.vercel.app",
+              "Cache-Control": 'no-cache'
             },
             body: formData,
           });


### PR DESCRIPTION
Change add and edit fruit location hooks to properly catch s3 upload errors, and cause the add/edit to still succeed, just without changing/including image link.
Prevent browser from caching the add/edit headers